### PR TITLE
update file node configuration to provide S3 credentials and force path style

### DIFF
--- a/store/s3store/config.go
+++ b/store/s3store/config.go
@@ -4,10 +4,17 @@ type configSource interface {
 	GetS3Store() Config
 }
 
+type Credentials struct {
+	AccessKey string `yaml:"accessKey"`
+	SecretKey string `yaml:"secretKey"`
+}
+
 type Config struct {
-	Profile    string `yaml:"profile"`
-	Region     string `yaml:"region"`
-	Bucket     string `yaml:"bucket"`
-	Endpoint   string `yaml:"endpoint"`
-	MaxThreads int    `yaml:"maxThreads"`
+	Profile        string      `yaml:"profile"`
+	Region         string      `yaml:"region"`
+	Bucket         string      `yaml:"bucket"`
+	Endpoint       string      `yaml:"endpoint"`
+	MaxThreads     int         `yaml:"maxThreads"`
+	Credentials    Credentials `yaml:"credentials"`
+	ForcePathStyle bool        `yaml:"forcePathStyle"`
 }

--- a/store/s3store/s3store.go
+++ b/store/s3store/s3store.go
@@ -57,7 +57,7 @@ func (s *s3store) Init(a *app.App) (err error) {
 		endpoint = aws.String(conf.Endpoint)
 	}
 
-	var creds *credentials.Credentials = nil
+	var creds *credentials.Credentials
 	// If creds are provided in the configuration, they are directly forwarded to the client as static credentials.
 	// This is mainly used for self-hosted scenarii where users store the data in a S3-compatible object store. In that
 	// case it does not really make sense to create an AWS configuration since there is no related AWS account.


### PR DESCRIPTION
### Description

for self-hosted use cases, users might use an S3-compatible service like MinIO. This service requires authentication using an access key and a secret key however I think it does not really make sense for users to create an AWS configuration on the machine since there is no AWS account involved.

Moreover, for using MinIO, path style is mandatory unless users setup some kind of DNS resolution for their bucket. I think it is best to avoid this complication and simply force the path style with the related option in the AWS SDK. Without that option set in the case of minio, errors are thrown because the minio service cannot be resolved by the DNS resolver.

All this has been tested with MinIO.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

None

### Mobile & Desktop Screenshots/Recordings

NA

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [x] 🙋 no, because it's hard to test without adding the minio dependency but I'm open to discuss it

### Added to documentation?

- [ ] 📜 README.md
- [x] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed
