### PR TITLE
filenode: bulk CID existence check for BlocksCheck (GO-7221)

### DIFF
--- a/filenode/filenode.go
+++ b/filenode/filenode.go
@@ -140,20 +140,37 @@ func (fn *fileNode) Check(ctx context.Context, spaceId string, cids ...cid.Cid) 
 			inSpaceM[inSp.KeyString()] = struct{}{}
 		}
 	}
-	for _, k := range cids {
-		var res = &fileproto.BlockAvailability{
+
+	// Collect the CIDs not found in the space; resolve their global existence
+	// in one pipelined call.
+	missed := make([]cid.Cid, 0, len(cids))
+	missedIdx := make([]int, 0, len(cids))
+	for i, k := range cids {
+		if _, ok := inSpaceM[k.KeyString()]; !ok {
+			missed = append(missed, k)
+			missedIdx = append(missedIdx, i)
+		}
+	}
+	var globallyExists []bool
+	if len(missed) > 0 {
+		if globallyExists, err = fn.index.CidExistsBulk(ctx, missed); err != nil {
+			return nil, err
+		}
+	}
+	missedPos := make(map[int]int, len(missedIdx))
+	for pos, i := range missedIdx {
+		missedPos[i] = pos
+	}
+
+	for i, k := range cids {
+		res := &fileproto.BlockAvailability{
 			Cid:    k.Bytes(),
 			Status: fileproto.AvailabilityStatus_NotExists,
 		}
 		if _, ok := inSpaceM[k.KeyString()]; ok {
 			res.Status = fileproto.AvailabilityStatus_ExistsInSpace
-		} else {
-			var ex bool
-			if ex, err = fn.index.CidExists(ctx, k); err != nil {
-				return nil, err
-			} else if ex {
-				res.Status = fileproto.AvailabilityStatus_Exists
-			}
+		} else if pos, ok := missedPos[i]; ok && globallyExists[pos] {
+			res.Status = fileproto.AvailabilityStatus_Exists
 		}
 		result = append(result, res)
 	}

--- a/filenode/filenode_test.go
+++ b/filenode/filenode_test.go
@@ -219,8 +219,7 @@ func TestFileNode_Check(t *testing.T) {
 	fx.index.EXPECT().Migrate(ctx, storeKey)
 	fx.index.EXPECT().CheckAndMoveOwnership(ctx, storeKey, storeKey.GroupId, gomock.Any()).Return(nil)
 	fx.index.EXPECT().CidExistsInSpace(ctx, storeKey, testutil.BlocksToKeys(bs)).Return(testutil.BlocksToKeys(bs[:1]), nil)
-	fx.index.EXPECT().CidExists(ctx, bs[1].Cid()).Return(true, nil)
-	fx.index.EXPECT().CidExists(ctx, bs[2].Cid()).Return(false, nil)
+	fx.index.EXPECT().CidExistsBulk(ctx, testutil.BlocksToKeys(bs[1:])).Return([]bool{true, false}, nil)
 	resp, err := fx.handler.BlocksCheck(ctx, &fileproto.BlocksCheckRequest{
 		SpaceId: storeKey.SpaceId,
 		Cids:    cids,

--- a/index/cids.go
+++ b/index/cids.go
@@ -134,6 +134,14 @@ func (ri *redisIndex) BlocksAdd(ctx context.Context, bs []blocks.Block) (err err
 	return
 }
 
+// CidExistsBulk returns, for each input CID, whether it exists in the global
+// index (either live in Redis or in persistent store). It is optimized for
+// BlocksCheck: no distributed locks, no usage-tracker writes, no restore of
+// evicted keys. Order of the returned slice matches the input order.
+func (ri *redisIndex) CidExistsBulk(ctx context.Context, cids []cid.Cid) (exists []bool, err error) {
+	return nil, errors.New("CidExistsBulk: not implemented")
+}
+
 func (ri *redisIndex) CidExistsInSpace(ctx context.Context, k Key, cids []cid.Cid) (exists []cid.Cid, err error) {
 	_, release, err := ri.AcquireKey(ctx, SpaceKey(k))
 	if err != nil {

--- a/index/cids.go
+++ b/index/cids.go
@@ -139,7 +139,99 @@ func (ri *redisIndex) BlocksAdd(ctx context.Context, bs []blocks.Block) (err err
 // BlocksCheck: no distributed locks, no usage-tracker writes, no restore of
 // evicted keys. Order of the returned slice matches the input order.
 func (ri *redisIndex) CidExistsBulk(ctx context.Context, cids []cid.Cid) (exists []bool, err error) {
-	return nil, errors.New("CidExistsBulk: not implemented")
+	if len(cids) == 0 {
+		return nil, nil
+	}
+	exists = make([]bool, len(cids))
+
+	// Phase A: pipelined EXISTS against per-CID keys in Redis.
+	existsCmds := make([]*redis.IntCmd, len(cids))
+	if _, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for i, c := range cids {
+			existsCmds[i] = pipe.Exists(ctx, CidKey(c))
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	type missed struct {
+		idx int
+		key string
+	}
+	missedByPart := make(map[string][]missed)
+	for i, c := range cids {
+		n, e := existsCmds[i].Result()
+		if e != nil {
+			return nil, e
+		}
+		if n > 0 {
+			exists[i] = true
+			continue
+		}
+		key := CidKey(c)
+		bfKey := bloomFilterKey(key)
+		missedByPart[bfKey] = append(missedByPart[bfKey], missed{idx: i, key: key})
+	}
+	if len(missedByPart) == 0 {
+		return exists, nil
+	}
+
+	// Phase B: pipelined BFMEXISTS per partition.
+	bfCmds := make(map[string]*redis.BoolSliceCmd, len(missedByPart))
+	if _, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for bfKey, ms := range missedByPart {
+			items := make([]interface{}, len(ms))
+			for i, m := range ms {
+				items[i] = m.key
+			}
+			bfCmds[bfKey] = pipe.BFMExists(ctx, bfKey, items...)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	type candidate struct {
+		idx int
+		key string
+	}
+	var candidates []candidate
+	for bfKey, ms := range missedByPart {
+		bfRes, e := bfCmds[bfKey].Result()
+		if e != nil {
+			return nil, e
+		}
+		for i, hit := range bfRes {
+			if hit {
+				candidates = append(candidates, candidate{idx: ms[i].idx, key: ms[i].key})
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return exists, nil
+	}
+
+	// Phase C: parallel persistStore fallback for bloom-positive candidates.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for _, cand := range candidates {
+		cand := cand
+		g.Go(func() error {
+			val, e := ri.persistStore.IndexGet(gctx, cand.key)
+			if e != nil {
+				return e
+			}
+			if val != nil {
+				exists[cand.idx] = true
+			}
+			return nil
+		})
+	}
+	if err = g.Wait(); err != nil {
+		return nil, err
+	}
+	return exists, nil
 }
 
 func (ri *redisIndex) CidExistsInSpace(ctx context.Context, k Key, cids []cid.Cid) (exists []cid.Cid, err error) {

--- a/index/cids_test.go
+++ b/index/cids_test.go
@@ -1,13 +1,17 @@
 package index
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/anyproto/any-sync-filenode/config"
 	"github.com/anyproto/any-sync-filenode/index/indexproto"
 	"github.com/anyproto/any-sync-filenode/testutil"
 )
@@ -146,4 +150,62 @@ func TestRedisIndex_CidExists(t *testing.T) {
 			assert.False(t, ok)
 		}
 	}
+}
+
+func TestRedisIndex_CidExistsBulk(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+
+		res, err := fx.CidExistsBulk(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("redis hits and misses", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+
+		live := testutil.NewRandBlocks(3)
+		missing := testutil.NewRandBlocks(2)
+		require.NoError(t, fx.BlocksAdd(ctx, live))
+
+		all := append(append([]cid.Cid{}, testutil.BlocksToKeys(live)...), testutil.BlocksToKeys(missing)...)
+
+		res, err := fx.CidExistsBulk(ctx, all)
+		require.NoError(t, err)
+		require.Equal(t, []bool{true, true, true, false, false}, res)
+	})
+
+	t.Run("hit via persistStore after eviction", func(t *testing.T) {
+		fx := newFixtureConfig(t, &config.Config{DefaultLimit: 1024, PersistTtl: 1})
+		defer fx.Finish(t)
+
+		bs := testutil.NewRandBlocks(2)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+
+		dumps := make(map[string][]byte, len(bs))
+		for _, b := range bs {
+			b := b
+			fx.persistStore.EXPECT().IndexPut(ctx, CidKey(b.Cid()), gomock.Any()).
+				Do(func(_ context.Context, key string, value []byte) {
+					dumps[key] = append([]byte(nil), value...)
+				})
+		}
+
+		time.Sleep(time.Second * 2)
+		fx.PersistKeys(ctx)
+
+		for _, b := range bs {
+			b := b
+			fx.persistStore.EXPECT().IndexGet(ctx, CidKey(b.Cid())).
+				DoAndReturn(func(_ context.Context, key string) ([]byte, error) {
+					return dumps[key], nil
+				})
+		}
+
+		res, err := fx.CidExistsBulk(ctx, testutil.BlocksToKeys(bs))
+		require.NoError(t, err)
+		assert.Equal(t, []bool{true, true}, res)
+	})
 }

--- a/index/cids_test.go
+++ b/index/cids_test.go
@@ -198,7 +198,7 @@ func TestRedisIndex_CidExistsBulk(t *testing.T) {
 
 		for _, b := range bs {
 			b := b
-			fx.persistStore.EXPECT().IndexGet(ctx, CidKey(b.Cid())).
+			fx.persistStore.EXPECT().IndexGet(gomock.Any(), CidKey(b.Cid())).
 				DoAndReturn(func(_ context.Context, key string) ([]byte, error) {
 					return dumps[key], nil
 				})

--- a/index/index.go
+++ b/index/index.go
@@ -57,6 +57,7 @@ type Index interface {
 
 	WaitCidExists(ctx context.Context, c cid.Cid) (err error)
 	CidExists(ctx context.Context, c cid.Cid) (ok bool, err error)
+	CidExistsBulk(ctx context.Context, cids []cid.Cid) (exists []bool, err error)
 	CidEntries(ctx context.Context, cids []cid.Cid) (entries *CidEntries, err error)
 	CidEntriesByBlocks(ctx context.Context, bs []blocks.Block) (entries *CidEntries, err error)
 	CidExistsInSpace(ctx context.Context, key Key, cids []cid.Cid) (exists []cid.Cid, err error)

--- a/index/mock_index/mock_index.go
+++ b/index/mock_index/mock_index.go
@@ -206,6 +206,21 @@ func (mr *MockIndexMockRecorder) CidExists(ctx, c any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CidExists", reflect.TypeOf((*MockIndex)(nil).CidExists), ctx, c)
 }
 
+// CidExistsBulk mocks base method.
+func (m *MockIndex) CidExistsBulk(ctx context.Context, cids []cid.Cid) ([]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CidExistsBulk", ctx, cids)
+	ret0, _ := ret[0].([]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CidExistsBulk indicates an expected call of CidExistsBulk.
+func (mr *MockIndexMockRecorder) CidExistsBulk(ctx, cids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CidExistsBulk", reflect.TypeOf((*MockIndex)(nil).CidExistsBulk), ctx, cids)
+}
+
 // CidExistsInSpace mocks base method.
 func (m *MockIndex) CidExistsInSpace(ctx context.Context, key index.Key, cids []cid.Cid) ([]cid.Cid, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why

`BlocksCheck` phase 2 ran a serial `CidExists` loop over every CID not found in the requested space. Each CID cost a redsync distributed mutex + `EXISTS` + optional `BFEXISTS` + optional S3 `IndexGet` + a `ZADD` usage write — multi-RTT per CID. 5k new CIDs (typical pre-upload dedup check) takes seconds and pressures the redsync pool. Details: [GO-7221](https://linear.app/anytype/issue/GO-7221).

## Changes

- New `Index.CidExistsBulk(ctx, cids) ([]bool, error)`: pipelined `EXISTS` → partition-grouped pipelined `BFMEXISTS` → parallel `persistStore.IndexGet` (errgroup, limit 10). No locks, no usage-tracker writes.
- `fileNode.Check` calls `CidExistsBulk` once on the miss-in-space subset instead of looping `CidExists`.
- Response semantics unchanged (per-CID order, three statuses).

## Test plan

- [x] `go test ./index/...` — new `TestRedisIndex_CidExistsBulk` covers redis hit, persistStore-after-eviction hit, and unknown CID
- [x] `go test ./filenode/...` — `TestFileNode_Check` updated
- [x] `go test ./...` passes