### PR TITLE
Atomic space ownership move via Lua scripts

### DIFF
--- a/index/loader.go
+++ b/index/loader.go
@@ -77,6 +77,13 @@ func (ri *redisIndex) AcquireKey(ctx context.Context, key string) (exists bool, 
 }
 
 func (ri *redisIndex) AcquireSpace(ctx context.Context, key Key) (entry groupSpaceEntry, release func(), err error) {
+	return ri.acquireSpace(ctx, key, "")
+}
+
+// acquireSpace does the same as AcquireSpace; a non-empty altGroupId is an
+// additionally accepted owner group of the space - Move uses it to resume a
+// half-applied ownership transfer that has already rewritten the space info
+func (ri *redisIndex) acquireSpace(ctx context.Context, key Key, altGroupId string) (entry groupSpaceEntry, release func(), err error) {
 	gExists, gRelease, err := ri.AcquireKey(ctx, GroupKey(key))
 	if err != nil {
 		return
@@ -122,7 +129,7 @@ func (ri *redisIndex) AcquireSpace(ctx context.Context, key Key) (entry groupSpa
 		return
 	}
 
-	if entry.space.GetGroupId() != key.GroupId {
+	if gid := entry.space.GetGroupId(); gid != key.GroupId && (altGroupId == "" || gid != altGroupId) {
 		gRelease()
 		sRelease()
 		err = fmt.Errorf("space and group mismatched")

--- a/index/move.go
+++ b/index/move.go
@@ -79,10 +79,9 @@ func (ri *redisIndex) CheckAndMoveOwnership(ctx context.Context, key Key, oldIde
 // move was already applied but the src cleanup didn't finish (crash between
 // the two scripts); the marker is removed after the src side succeeds.
 // KEYS: [1] dest space key, [2] dest group key
-// ARGV: [1] marker field, [2] marker token (src group id),
-//
-//	[3] space hash dump ('' - skip restore), [4] space info ('' - keep existing),
-//	[5] group info, [6..] cid field/delta pairs
+// ARGV: [1] marker field, [2] marker token (src group id), [3] space hash dump
+// (empty - skip restore), [4] space info (empty - keep existing), [5] group info,
+// [6..] cid field/delta pairs
 var moveDestScript = redis.NewScript(`
 if redis.call('HGET', KEYS[2], ARGV[1]) == ARGV[2] then
 	return 0
@@ -120,6 +119,12 @@ end
 return 1
 `)
 
+// moveMarker names the field in the dest group hash guarding against
+// re-applying the dest side of a crashed move; its value is the src group id
+func moveMarker(spaceId string) string {
+	return "mv:" + spaceId
+}
+
 // movePlan holds everything precomputed under the space/group locks so the
 // move applies as two atomic scripts: one per cluster slot side.
 type movePlan struct {
@@ -149,7 +154,9 @@ func (ri *redisIndex) Move(ctx context.Context, dest, src Key) (err error) {
 	if dest.SpaceId != src.SpaceId {
 		return fmt.Errorf("spaceId should be the same for both keys")
 	}
-	srcEntry, srcRelease, err := ri.AcquireSpace(ctx, src)
+	// accept a space already pointing at the dest group: with colliding group
+	// hashes the dest side of a crashed move rewrites the shared space key
+	srcEntry, srcRelease, err := ri.acquireSpace(ctx, src, dest.GroupId)
 	if err != nil {
 		return
 	}
@@ -164,6 +171,18 @@ func (ri *redisIndex) Move(ctx context.Context, dest, src Key) (err error) {
 	destGroup, err := ri.getGroupEntry(ctx, dest)
 	if err != nil {
 		return
+	}
+
+	if srcEntry.space.GetGroupId() == dest.GroupId {
+		// the dest side was already applied by a previous attempt; without the
+		// marker the whole move completed - nothing to do
+		token, e := ri.cl.HGet(ctx, GroupKey(dest), moveMarker(src.SpaceId)).Result()
+		if e != nil && !errors.Is(e, redis.Nil) {
+			return e
+		}
+		if token != src.GroupId {
+			return nil
+		}
 	}
 
 	// in case of hash collision, we don't need to lock the space key twice
@@ -198,7 +217,7 @@ func (ri *redisIndex) prepareMove(ctx context.Context, dest, src Key, srcEntry g
 		dSK:         SpaceKey(dest),
 		sGK:         GroupKey(src),
 		dGK:         GroupKey(dest),
-		marker:      "mv:" + src.SpaceId,
+		marker:      moveMarker(src.SpaceId),
 		markerToken: src.GroupId,
 	}
 
@@ -305,6 +324,21 @@ func (ri *redisIndex) prepareMove(ctx context.Context, dest, src Key, srcEntry g
 					log.WarnCtx(ctx, "group: unable to decrement 0-ref", zap.String("spaceId", src.SpaceId))
 				}
 			}
+		}
+	}
+
+	// an isolated space carries its reserved limit between the groups
+	// (group.Limit = AccountLimit - sum of the isolated space limits);
+	// the move can't be refused, so the dest side clamps instead of erroring -
+	// CheckLimits enforces the account limit afterwards
+	if srcEntry.space.Limit != 0 && src.GroupId != dest.GroupId {
+		srcEntry.group.Limit += srcEntry.space.Limit
+		if destGroup.Limit < srcEntry.space.Limit {
+			log.WarnCtx(ctx, "move: dest group limit underflow",
+				zap.Uint64("limit", destGroup.Limit), zap.Uint64("spaceLimit", srcEntry.space.Limit), zap.String("spaceId", src.SpaceId))
+			destGroup.Limit = 0
+		} else {
+			destGroup.Limit -= srcEntry.space.Limit
 		}
 	}
 

--- a/index/move.go
+++ b/index/move.go
@@ -179,12 +179,31 @@ func (ri *redisIndex) Move(ctx context.Context, dest, src Key) (err error) {
 		return
 	}
 
+	// migrate the whole space hash (file entries and per-cid refcounts) to the new key;
+	// the info field is overwritten with the updated entry below
+	if sSK != dSK {
+		var dump string
+		dump, err = ri.cl.Dump(ctx, sSK).Result()
+		if err != nil && !errors.Is(err, redis.Nil) {
+			return
+		}
+		if !errors.Is(err, redis.Nil) {
+			if err = ri.cl.RestoreReplace(ctx, dSK, 0, dump).Err(); err != nil {
+				return
+			}
+		}
+		err = nil
+	}
+
 	_, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		srcEntry.space.Save(ctx, dest, pipe)
 		destGroup.AddSpaceId(src.SpaceId)
 		destGroup.Save(ctx, pipe)
 		return nil
 	})
+	if err != nil {
+		return
+	}
 
 	if sSK != dSK {
 		if err = ri.cl.Del(ctx, sSK).Err(); err != nil {

--- a/index/move.go
+++ b/index/move.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -70,16 +72,88 @@ func (ri *redisIndex) CheckAndMoveOwnership(ctx context.Context, key Key, oldIde
 	return ri.cl.Set(ctx, oKey, data, 0).Err()
 }
 
+// moveDestScript atomically applies the destination side of a space move:
+// restores the dumped space hash at the new key, writes the updated space and
+// group info entries and increments the group cid refcounts.
+// A marker field in the dest group hash makes the script a no-op when this
+// move was already applied but the src cleanup didn't finish (crash between
+// the two scripts); the marker is removed after the src side succeeds.
+// KEYS: [1] dest space key, [2] dest group key
+// ARGV: [1] marker field, [2] marker token (src group id),
+//
+//	[3] space hash dump ('' - skip restore), [4] space info ('' - keep existing),
+//	[5] group info, [6..] cid field/delta pairs
+var moveDestScript = redis.NewScript(`
+if redis.call('HGET', KEYS[2], ARGV[1]) == ARGV[2] then
+	return 0
+end
+if ARGV[3] ~= '' then
+	redis.call('RESTORE', KEYS[1], 0, ARGV[3], 'REPLACE')
+end
+if ARGV[4] ~= '' then
+	redis.call('HSET', KEYS[1], 'info', ARGV[4])
+end
+redis.call('HSET', KEYS[2], 'info', ARGV[5])
+for i = 6, #ARGV, 2 do
+	redis.call('HINCRBY', KEYS[2], ARGV[i], ARGV[i + 1])
+end
+redis.call('HSET', KEYS[2], ARGV[1], ARGV[2])
+return 1
+`)
+
+// moveSrcScript atomically applies the source side of a space move:
+// decrements the group cid refcounts (dropping the emptied fields), writes the
+// updated group info entry and deletes the moved space hash.
+// KEYS: [1] src space key, [2] src group key
+// ARGV: [1] group info, [2] '1' to delete the space key, [3..] cid field/delta pairs
+var moveSrcScript = redis.NewScript(`
+for i = 3, #ARGV, 2 do
+	local v = redis.call('HINCRBY', KEYS[2], ARGV[i], -ARGV[i + 1])
+	if v <= 0 then
+		redis.call('HDEL', KEYS[2], ARGV[i])
+	end
+end
+redis.call('HSET', KEYS[2], 'info', ARGV[1])
+if ARGV[2] == '1' then
+	redis.call('DEL', KEYS[1])
+end
+return 1
+`)
+
+// movePlan holds everything precomputed under the space/group locks so the
+// move applies as two atomic scripts: one per cluster slot side.
+type movePlan struct {
+	sSK, dSK string
+	sGK, dGK string
+	// marker field in the dest group hash guarding against re-applying the
+	// dest side when a crashed move is retried
+	marker      string
+	markerToken string
+	// dump of the whole src space hash; empty when the src key is missing or
+	// the move stays on the same key (group hash collision)
+	dump string
+	// updated space info entry; nil means keep the existing dest info
+	// (re-run of an already applied move)
+	spaceInfo     []byte
+	srcGroupInfo  []byte
+	destGroupInfo []byte
+	// per-cid refcount transfer: space refcounts count file bindings, so the
+	// group refcounts move by the same amount
+	cidFields []string
+	cidDeltas []int64
+	cids      *CidEntries
+}
+
 func (ri *redisIndex) Move(ctx context.Context, dest, src Key) (err error) {
 	log.InfoCtx(ctx, "move space", zap.String("spaceId", dest.SpaceId), zap.String("src", src.GroupId), zap.String("dest", dest.GroupId))
 	if dest.SpaceId != src.SpaceId {
 		return fmt.Errorf("spaceId should be the same for both keys")
 	}
-	srcEntry, scrRelease, err := ri.AcquireSpace(ctx, src)
+	srcEntry, srcRelease, err := ri.AcquireSpace(ctx, src)
 	if err != nil {
 		return
 	}
-	defer scrRelease()
+	defer srcRelease()
 
 	_, destGRelease, err := ri.AcquireKey(ctx, GroupKey(dest))
 	if err != nil {
@@ -93,122 +167,197 @@ func (ri *redisIndex) Move(ctx context.Context, dest, src Key) (err error) {
 	}
 
 	// in case of hash collision, we don't need to lock the space key twice
-	sSK := SpaceKey(src)
-	dSK := SpaceKey(dest)
-	if sSK != dSK {
-		_, destSRelease, err := ri.AcquireKey(ctx, SpaceKey(dest))
+	destSpaceExists := srcEntry.spaceExists
+	if SpaceKey(src) != SpaceKey(dest) {
+		var destSRelease func()
+		destSpaceExists, destSRelease, err = ri.AcquireKey(ctx, SpaceKey(dest))
 		if err != nil {
 			return err
 		}
 		defer destSRelease()
 	}
 
-	// collect all the space cids
-	keys, err := ri.cl.HKeys(ctx, sSK).Result()
+	plan, err := ri.prepareMove(ctx, dest, src, srcEntry, destGroup, destSpaceExists)
 	if err != nil {
 		return
 	}
-	var cids []string
+	defer plan.cids.Release()
+
+	if err = ri.applyMoveDest(ctx, plan); err != nil {
+		return
+	}
+	if err = ri.applyMoveSrc(ctx, plan); err != nil {
+		return
+	}
+	return ri.cl.HDel(ctx, plan.dGK, plan.marker).Err()
+}
+
+func (ri *redisIndex) prepareMove(ctx context.Context, dest, src Key, srcEntry groupSpaceEntry, destGroup *groupEntry, destSpaceExists bool) (plan *movePlan, err error) {
+	plan = &movePlan{
+		sSK:         SpaceKey(src),
+		dSK:         SpaceKey(dest),
+		sGK:         GroupKey(src),
+		dGK:         GroupKey(dest),
+		marker:      "mv:" + src.SpaceId,
+		markerToken: src.GroupId,
+	}
+
+	// collect the space cid fields
+	keys, err := ri.cl.HKeys(ctx, plan.sSK).Result()
+	if err != nil {
+		return nil, err
+	}
+	var cidFields = make([]string, 0, len(keys))
 	for _, k := range keys {
 		if strings.HasPrefix(k, "c:") {
-			cids = append(cids, k[2:])
+			cidFields = append(cidFields, k)
 		}
 	}
 
-	// load entries
-	cidEntries, err := ri.CidEntriesByString(ctx, cids)
-	if err != nil {
-		return
-	}
-	defer cidEntries.Release()
+	// fetch the refcounts and the space hash dump in one pipeline;
+	// isolated spaces don't count against the group refcounts
+	var (
+		needRefs = srcEntry.space.Limit == 0 && len(cidFields) != 0
+		needDump = plan.sSK != plan.dSK && srcEntry.spaceExists
 
-	// increment cid refs in the dest group
-	dGK := GroupKey(dest)
-	cmdGroupExists := make([]*redis.IntCmd, len(cidEntries.entries))
-	_, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		for i, cidE := range cidEntries.entries {
-			cmdGroupExists[i] = pipe.HIncrBy(ctx, dGK, CidKey(cidE.Cid), 1)
-		}
-		return nil
-	})
-	if err != nil {
-		return
-	}
-
-	// calculate the dest group sums
-	for i, cmd := range cmdGroupExists {
-		res, _ := cmd.Result()
-		if res == 1 {
-			destGroup.CidCount++
-			destGroup.Size += cidEntries.entries[i].Size
-		}
-	}
-
-	// remove cids from the src group
-	sGK := GroupKey(src)
-	var srcCmdGroupDecr = make([]*redis.IntCmd, len(cidEntries.entries))
-	_, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		for i, cidE := range cidEntries.entries {
-			srcCmdGroupDecr[i] = pipe.HIncrBy(ctx, sGK, CidKey(cidE.Cid), -1)
-		}
-		return nil
-	})
-	if err != nil {
-		return
-	}
-
-	// remove unneeded cids / update sums / save the src group entry
-	_, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		for i, cmd := range srcCmdGroupDecr {
-			res, _ := cmd.Result()
-			if res == 0 {
-				srcEntry.group.CidCount--
-				srcEntry.group.Size -= cidEntries.entries[i].Size
-				pipe.HDel(ctx, sGK, CidKey(cidEntries.entries[i].Cid))
+		spaceRefsCmd, destRefsCmd, srcRefsCmd *redis.SliceCmd
+		dumpCmd                               *redis.StringCmd
+	)
+	if needRefs || needDump {
+		if _, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+			if needRefs {
+				spaceRefsCmd = pipe.HMGet(ctx, plan.sSK, cidFields...)
+				destRefsCmd = pipe.HMGet(ctx, plan.dGK, cidFields...)
+				srcRefsCmd = pipe.HMGet(ctx, plan.sGK, cidFields...)
 			}
-		}
-		srcEntry.space.GroupId = dest.GroupId
-		srcEntry.space.Save(ctx, src, pipe)
-		srcEntry.group.SpaceIds = slices.DeleteFunc(srcEntry.group.SpaceIds, func(spaceId string) bool {
-			return spaceId == src.SpaceId
-		})
-		srcEntry.group.Save(ctx, pipe)
-		return nil
-	})
-	if err != nil {
-		return
-	}
-
-	// migrate the whole space hash (file entries and per-cid refcounts) to the new key;
-	// the info field is overwritten with the updated entry below
-	if sSK != dSK {
-		var dump string
-		dump, err = ri.cl.Dump(ctx, sSK).Result()
-		if err != nil && !errors.Is(err, redis.Nil) {
-			return
-		}
-		if !errors.Is(err, redis.Nil) {
-			if err = ri.cl.RestoreReplace(ctx, dSK, 0, dump).Err(); err != nil {
-				return
+			if needDump {
+				dumpCmd = pipe.Dump(ctx, plan.sSK)
 			}
+			return nil
+		}); err != nil && !errors.Is(err, redis.Nil) {
+			return nil, err
 		}
 		err = nil
 	}
-
-	_, err = ri.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		srcEntry.space.Save(ctx, dest, pipe)
-		destGroup.AddSpaceId(src.SpaceId)
-		destGroup.Save(ctx, pipe)
-		return nil
-	})
-	if err != nil {
-		return
-	}
-
-	if sSK != dSK {
-		if err = ri.cl.Del(ctx, sSK).Err(); err != nil {
-			return
+	if needDump {
+		if plan.dump, err = dumpCmd.Result(); err != nil {
+			if !errors.Is(err, redis.Nil) {
+				return nil, err
+			}
+			plan.dump = ""
+			err = nil
 		}
 	}
-	return
+
+	// keep only the cids with a valid refcount to transfer
+	var origIdx = make([]int, 0, len(cidFields))
+	if needRefs {
+		spaceRefs := spaceRefsCmd.Val()
+		for i, k := range cidFields {
+			ref, _ := spaceRefs[i].(string)
+			delta, e := strconv.ParseInt(ref, 10, 64)
+			if e != nil || delta <= 0 {
+				log.WarnCtx(ctx, "move: skip cid with invalid space refcount",
+					zap.String("spaceId", src.SpaceId), zap.String("field", k), zap.String("value", ref))
+				continue
+			}
+			plan.cidFields = append(plan.cidFields, k)
+			plan.cidDeltas = append(plan.cidDeltas, delta)
+			origIdx = append(origIdx, i)
+		}
+	}
+
+	// load the entries to lock the cids and get their sizes
+	var cidStrings = make([]string, len(plan.cidFields))
+	for i, k := range plan.cidFields {
+		cidStrings[i] = k[2:]
+	}
+	if plan.cids, err = ri.CidEntriesByString(ctx, cidStrings); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			plan.cids.Release()
+		}
+	}()
+
+	// calculate the group entry sums
+	if len(plan.cidFields) != 0 {
+		destRefs := destRefsCmd.Val()
+		srcRefs := srcRefsCmd.Val()
+		for i, orig := range origIdx {
+			size := plan.cids.entries[i].Size
+			if destRefs[orig] == nil {
+				destGroup.CidCount++
+				destGroup.Size += size
+			}
+			srcRef, _ := srcRefs[orig].(string)
+			oldVal, _ := strconv.ParseInt(srcRef, 10, 64)
+			if oldVal > 0 && oldVal-plan.cidDeltas[i] <= 0 {
+				if srcEntry.group.Size-size > srcEntry.group.Size {
+					log.WarnCtx(ctx, "group: unable to decrement size", zap.Uint64("before", srcEntry.group.Size), zap.Uint64("size", size), zap.String("spaceId", src.SpaceId))
+				} else {
+					srcEntry.group.Size -= size
+				}
+				if srcEntry.group.CidCount != 0 {
+					srcEntry.group.CidCount--
+				} else {
+					log.WarnCtx(ctx, "group: unable to decrement 0-ref", zap.String("spaceId", src.SpaceId))
+				}
+			}
+		}
+	}
+
+	now := time.Now().Unix()
+
+	// don't overwrite the dest space info when the src key is already gone:
+	// it means a previous move was applied and the dest holds the actual entry
+	if srcEntry.spaceExists || !destSpaceExists {
+		srcEntry.space.GroupId = dest.GroupId
+		srcEntry.space.UpdateTime = now
+		if plan.spaceInfo, err = srcEntry.space.MarshalVT(); err != nil {
+			return nil, err
+		}
+	}
+
+	destGroup.AddSpaceId(src.SpaceId)
+	destGroup.UpdateTime = now
+	if plan.destGroupInfo, err = destGroup.MarshalVT(); err != nil {
+		return nil, err
+	}
+
+	srcEntry.group.SpaceIds = slices.DeleteFunc(srcEntry.group.SpaceIds, func(spaceId string) bool {
+		return spaceId == src.SpaceId
+	})
+	srcEntry.group.UpdateTime = now
+	if plan.srcGroupInfo, err = srcEntry.group.MarshalVT(); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func (ri *redisIndex) applyMoveDest(ctx context.Context, plan *movePlan) (err error) {
+	args := make([]interface{}, 0, 5+2*len(plan.cidFields))
+	var spaceInfo interface{} = ""
+	if plan.spaceInfo != nil {
+		spaceInfo = plan.spaceInfo
+	}
+	args = append(args, plan.marker, plan.markerToken, plan.dump, spaceInfo, plan.destGroupInfo)
+	for i, k := range plan.cidFields {
+		args = append(args, k, plan.cidDeltas[i])
+	}
+	return moveDestScript.Run(ctx, ri.cl, []string{plan.dSK, plan.dGK}, args...).Err()
+}
+
+func (ri *redisIndex) applyMoveSrc(ctx context.Context, plan *movePlan) (err error) {
+	deleteKey := "0"
+	if plan.sSK != plan.dSK {
+		deleteKey = "1"
+	}
+	args := make([]interface{}, 0, 2+2*len(plan.cidFields))
+	args = append(args, plan.srcGroupInfo, deleteKey)
+	for i, k := range plan.cidFields {
+		args = append(args, k, plan.cidDeltas[i])
+	}
+	return moveSrcScript.Run(ctx, ri.cl, []string{plan.sSK, plan.sGK}, args...).Err()
 }

--- a/index/move_test.go
+++ b/index/move_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -292,14 +291,7 @@ func TestRedisIndex_Move(t *testing.T) {
 		)
 
 		// isolate the space before any binds: binds don't count against the group
-		se, err := fx.getSpaceEntry(ctx, srcKey)
-		require.NoError(t, err)
-		se.Limit = 2048
-		_, err = fx.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-			se.Save(ctx, srcKey, pipe)
-			return nil
-		})
-		require.NoError(t, err)
+		require.NoError(t, fx.SetSpaceLimit(ctx, srcKey, 512))
 
 		bs := testutil.NewRandBlocks(3)
 		require.NoError(t, fx.BlocksAdd(ctx, bs))
@@ -326,12 +318,116 @@ func TestRedisIndex_Move(t *testing.T) {
 			}
 		}
 
+		// the reserved isolated limit moves with the space
+		srcGroup, err := fx.GroupInfo(ctx, srcKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, int(srcGroup.AccountLimit), int(srcGroup.Limit))
+		destGroup, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, int(destGroup.AccountLimit)-512, int(destGroup.Limit))
+
 		// space data survives the move intact
 		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
 		require.NoError(t, err)
 		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+		assert.Equal(t, 512, int(spaceAfter.Limit))
 		fileIds, err := fx.FilesList(ctx, movedKey)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"f1"}, fileIds)
+	})
+
+	t.Run("interrupted move with colliding hash is finished by retry", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		// these groups has an identical xxhash, so both keys share the space hash
+		var (
+			srcKey   = Key{"3325572473", "s1"}
+			movedKey = Key{"8117876798", "s1"}
+		)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+		sharedCids, err := fx.CidEntriesByBlocks(ctx, bs[:1])
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f2", sharedCids))
+		sharedCids.Release()
+
+		spaceBefore, err := fx.SpaceInfo(ctx, srcKey)
+		require.NoError(t, err)
+
+		// apply only the destination half, simulating a crash before the src cleanup
+		srcEntry, srcRelease, err := fx.AcquireSpace(ctx, srcKey)
+		require.NoError(t, err)
+		destGroup, err := fx.getGroupEntry(ctx, movedKey)
+		require.NoError(t, err)
+		plan, err := fx.prepareMove(ctx, movedKey, srcKey, srcEntry, destGroup, srcEntry.spaceExists)
+		require.NoError(t, err)
+		require.NoError(t, fx.applyMoveDest(ctx, plan))
+		plan.cids.Release()
+		srcRelease()
+
+		// the shared space key now points at the dest group; the retry must
+		// still complete the src side without double counting
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		val, err := fx.cl.HGet(ctx, GroupKey(movedKey), CidKey(bs[0].Cid())).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "2", val)
+		srcFields, err := fx.cl.HKeys(ctx, GroupKey(srcKey)).Result()
+		require.NoError(t, err)
+		for _, f := range srcFields {
+			assert.False(t, strings.HasPrefix(f, "c:"), "leftover src group cid ref %s", f)
+		}
+
+		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+		destGroupAfter, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(destGroupAfter.BytesUsage))
+		srcGroupAfter, err := fx.GroupInfo(ctx, srcKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(srcGroupAfter.BytesUsage))
+
+		require.NoError(t, fx.FileUnbind(ctx, movedKey, "f1", "f2"))
+		destGroupFinal, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(destGroupFinal.BytesUsage))
+	})
+
+	t.Run("repeated move with colliding hash is idempotent", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		// these groups has an identical xxhash, so both keys share the space hash
+		var (
+			srcKey   = Key{"3325572473", "s1"}
+			movedKey = Key{"8117876798", "s1"}
+		)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+
+		spaceBefore, err := fx.SpaceInfo(ctx, srcKey)
+		require.NoError(t, err)
+
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+		// simulate a crash before the owner record was persisted: Move runs again
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		val, err := fx.cl.HGet(ctx, GroupKey(movedKey), CidKey(bs[0].Cid())).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "1", val)
+		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+		assert.Equal(t, int(spaceBefore.FileCount), int(spaceAfter.FileCount))
 	})
 }

--- a/index/move_test.go
+++ b/index/move_test.go
@@ -1,9 +1,11 @@
 package index
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ipfs/go-cid"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -130,5 +132,206 @@ func TestRedisIndex_Move(t *testing.T) {
 		var srcKey = Key{"3325572473", "s1"}
 		var dstKey = Key{"8117876798", "s2"}
 		test(srcKey, dstKey)
+	})
+
+	t.Run("shared cid keeps file-binding refcounts", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		var (
+			srcKey   = Key{"g1", "s1"}
+			movedKey = Key{"g2", "s1"}
+		)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+		// f2 shares bs[0] with f1
+		sharedCids, err := fx.CidEntriesByBlocks(ctx, bs[:1])
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f2", sharedCids))
+		sharedCids.Release()
+
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		// group refcount must equal the number of file bindings, not 1 per distinct cid
+		val, err := fx.cl.HGet(ctx, GroupKey(movedKey), CidKey(bs[0].Cid())).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "2", val)
+
+		// unbinding both files must fully release the group usage
+		require.NoError(t, fx.FileUnbind(ctx, movedKey, "f1", "f2"))
+		groupAfter, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(groupAfter.BytesUsage))
+		fields, err := fx.cl.HKeys(ctx, GroupKey(movedKey)).Result()
+		require.NoError(t, err)
+		for _, f := range fields {
+			assert.False(t, strings.HasPrefix(f, "c:"), "leftover group cid ref %s", f)
+		}
+	})
+
+	t.Run("repeated move is idempotent", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		var (
+			srcKey   = Key{"g1", "s1"}
+			movedKey = Key{"g2", "s1"}
+		)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+
+		spaceBefore, err := fx.SpaceInfo(ctx, srcKey)
+		require.NoError(t, err)
+
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+		// simulate a crash before the owner record was persisted: Move runs again
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+		assert.Equal(t, int(spaceBefore.FileCount), int(spaceAfter.FileCount))
+
+		val, err := fx.cl.HGet(ctx, GroupKey(movedKey), CidKey(bs[0].Cid())).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "1", val)
+
+		fileIds, err := fx.FilesList(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"f1"}, fileIds)
+	})
+
+	t.Run("interrupted move is finished by retry", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		var (
+			srcKey   = Key{"g1", "s1"}
+			movedKey = Key{"g2", "s1"}
+		)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+		// f2 shares bs[0] with f1
+		sharedCids, err := fx.CidEntriesByBlocks(ctx, bs[:1])
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f2", sharedCids))
+		sharedCids.Release()
+
+		spaceBefore, err := fx.SpaceInfo(ctx, srcKey)
+		require.NoError(t, err)
+
+		// apply only the destination half of the move, simulating a crash
+		// before the src cleanup
+		srcEntry, srcRelease, err := fx.AcquireSpace(ctx, srcKey)
+		require.NoError(t, err)
+		destGroup, err := fx.getGroupEntry(ctx, movedKey)
+		require.NoError(t, err)
+		destSpaceExists, destSRelease, err := fx.AcquireKey(ctx, SpaceKey(movedKey))
+		require.NoError(t, err)
+		plan, err := fx.prepareMove(ctx, movedKey, srcKey, srcEntry, destGroup, destSpaceExists)
+		require.NoError(t, err)
+		require.NoError(t, fx.applyMoveDest(ctx, plan))
+		plan.cids.Release()
+		destSRelease()
+		srcRelease()
+
+		// both keys exist now; the retry must complete the move without
+		// applying the refcounts twice
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		val, err := fx.cl.HGet(ctx, GroupKey(movedKey), CidKey(bs[0].Cid())).Result()
+		require.NoError(t, err)
+		assert.Equal(t, "2", val)
+
+		srcExists, err := fx.cl.Exists(ctx, SpaceKey(srcKey)).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), srcExists)
+
+		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+
+		destGroupAfter, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(destGroupAfter.BytesUsage))
+		srcGroupAfter, err := fx.GroupInfo(ctx, srcKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(srcGroupAfter.BytesUsage))
+		assert.Len(t, srcGroupAfter.SpaceIds, 0)
+
+		// unbinding everything after the recovered move releases all usage
+		require.NoError(t, fx.FileUnbind(ctx, movedKey, "f1", "f2"))
+		destGroupFinal, err := fx.GroupInfo(ctx, movedKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(destGroupFinal.BytesUsage))
+		fields, err := fx.cl.HKeys(ctx, GroupKey(movedKey)).Result()
+		require.NoError(t, err)
+		for _, f := range fields {
+			assert.False(t, strings.HasPrefix(f, "c:"), "leftover group cid ref %s", f)
+		}
+	})
+
+	t.Run("isolated space move leaves groups untouched", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		var (
+			srcKey   = Key{"g1", "s1"}
+			movedKey = Key{"g2", "s1"}
+		)
+
+		// isolate the space before any binds: binds don't count against the group
+		se, err := fx.getSpaceEntry(ctx, srcKey)
+		require.NoError(t, err)
+		se.Limit = 2048
+		_, err = fx.cl.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+			se.Save(ctx, srcKey, pipe)
+			return nil
+		})
+		require.NoError(t, err)
+
+		bs := testutil.NewRandBlocks(3)
+		require.NoError(t, fx.BlocksAdd(ctx, bs))
+		cids, err := fx.CidEntriesByBlocks(ctx, bs)
+		require.NoError(t, err)
+		require.NoError(t, fx.FileBind(ctx, srcKey, "f1", cids))
+		cids.Release()
+
+		spaceBefore, err := fx.SpaceInfo(ctx, srcKey)
+		require.NoError(t, err)
+		require.Greater(t, int(spaceBefore.BytesUsage), 0)
+
+		require.NoError(t, fx.Move(ctx, movedKey, srcKey))
+
+		// neither group may hold cid refs or usage for an isolated space
+		for _, groupId := range []string{srcKey.GroupId, movedKey.GroupId} {
+			g, err := fx.GroupInfo(ctx, groupId)
+			require.NoError(t, err)
+			assert.Equal(t, 0, int(g.BytesUsage), "group %s", groupId)
+			fields, err := fx.cl.HKeys(ctx, GroupKey(Key{GroupId: groupId})).Result()
+			require.NoError(t, err)
+			for _, f := range fields {
+				assert.False(t, strings.HasPrefix(f, "c:"), "group %s leftover cid ref %s", groupId, f)
+			}
+		}
+
+		// space data survives the move intact
+		spaceAfter, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(spaceAfter.BytesUsage))
+		fileIds, err := fx.FilesList(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"f1"}, fileIds)
 	})
 }

--- a/index/move_test.go
+++ b/index/move_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -87,6 +88,36 @@ func TestRedisIndex_Move(t *testing.T) {
 		assert.Len(t, bobGroupAfter.SpaceIds, 0)
 		assert.Len(t, aliceGroupAfter.SpaceIds, 2)
 		assert.Equal(t, int(spaceAfter.BytesUsage), int(spaceBefore.BytesUsage))
+
+		// file entries and per-cid refcounts must survive the move
+		movedKey := Key{aliceKey.GroupId, bobKey.SpaceId}
+		fileIds, err := fx.FilesList(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"f1"}, fileIds)
+
+		fileInfos, err := fx.FileInfo(ctx, movedKey, "f1")
+		require.NoError(t, err)
+		require.Len(t, fileInfos, 1)
+		assert.Equal(t, int(spaceBefore.BytesUsage), int(fileInfos[0].BytesUsage))
+		assert.Equal(t, len(bobBS), int(fileInfos[0].CidsCount))
+
+		bobCidList := make([]cid.Cid, len(bobBS))
+		for i, b := range bobBS {
+			bobCidList[i] = b.Cid()
+		}
+		inSpace, err := fx.CidExistsInSpace(ctx, movedKey, bobCidList)
+		require.NoError(t, err)
+		assert.Len(t, inSpace, len(bobBS))
+
+		// unbind after the move must release the usage from the new group
+		require.NoError(t, fx.FileUnbind(ctx, movedKey, "f1"))
+		aliceGroupFinal, err := fx.GroupInfo(ctx, aliceKey.GroupId)
+		require.NoError(t, err)
+		assert.Equal(t, int(aliceGroupBefore.BytesUsage), int(aliceGroupFinal.BytesUsage))
+		spaceFinal, err := fx.SpaceInfo(ctx, movedKey)
+		require.NoError(t, err)
+		assert.Equal(t, 0, int(spaceFinal.BytesUsage))
+		assert.Equal(t, 0, int(spaceFinal.FileCount))
 	}
 
 	t.Run("move", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Space redis hashes are keyed by a hash tag derived from `GroupId`, so an ownership transfer rekeys the space. `Move` had two classes of bugs:

1. **Data loss**: only the `info` field was copied to the new key; the old hash was `DEL`'d with all `f:{fileId}` entries and per-cid `c:{cid}` refcounts. The space lost its file index, usage could never be decremented again, clients re-uploaded and double-counted.
2. **No atomicity**: ~6 independent redis writes; a crash mid-move left group counters, the space hash and the owner record inconsistent, and a retry double-applied the group refcount increments.

## Fix

`Move` now precomputes everything in Go under the existing locks, then applies exactly two atomic Lua scripts — one per cluster slot (`SpaceKey` and `GroupKey` share the `{xxhash(groupId)}` tag):

- **dest script**: `RESTORE REPLACE` the dumped space hash, write space+group info, `HINCRBY` group cid refcounts
- **src script**: decrement/`HDEL` group cid refcounts, write group info, `DEL` the old space key

The single remaining crash window (between the scripts) is recoverable: the dest script writes a marker field (`mv:{spaceId}` = src group) into the dest group hash and no-ops when it sees it again, so a retry finishes the src side without double counting. The marker is removed after success.

Accounting fixes surfaced by pinning the semantics (each covered by a test that fails on the old code):

- group refcounts transfer by the space per-cid refcount (file bindings, consistent with bind/unbind/check), not 1 per distinct cid — shared cids no longer corrupt the dest group on unbind
- isolated spaces (`space.Limit != 0`) no longer pollute group refcounts on move
- a retried move that finds the src key already gone no longer wipes the dest space info

Prepare-phase reads (3×`HMGET` + `DUMP`) go out in one pipeline; the whole move is a fixed ~6 round trips plus cid entry locking.

Requires redis ≥ 5 (`RESTORE` inside Lua / effects replication) — anything running RedisBloom qualifies.

## Tests

`TestRedisIndex_Move` extended: files/cids/unbind accounting survive the move (from the previous commit), plus shared-cid refcounts, repeated-move idempotency, interrupted-move recovery (dest half applied, then full retry), isolated-space moves. All new assertions fail against the old `Move`.

## Review follow-ups

An independent review confirmed two more bugs, fixed here:

- **Collision-path retry bricked the space** (pre-existing): with colliding group hashes the dest script rewrites the shared space key's `GroupId`, so any retry failed the acquire-time mismatch check forever. `Move` now accepts a space already pointing at the dest group, and short-circuits when the marker shows the move fully completed (a redundant re-run can no longer double-apply refcounts).
- **Isolated space moves stranded the reserved limit**: `group.Limit = AccountLimit − Σ isolated space limits` (maintained by `SetSpaceLimit`/`spaceDelete`) was not transferred — src group lost capacity, dest group over-allocated. `Move` now refunds the src group and deducts from the dest group (clamped, since a move can't be refused; `CheckLimits` enforces afterwards).

New tests: interrupted + repeated moves with colliding hashes, isolated-space limit transfer (the isolated test now goes through the real `SetSpaceLimit`).
