### PR TITLE
Index consistency and input validation fixes

### DIFF
--- a/filenode/filenode_test.go
+++ b/filenode/filenode_test.go
@@ -164,6 +164,32 @@ func TestFileNode_Add(t *testing.T) {
 	})
 }
 
+func TestFileNode_BlockPushMany(t *testing.T) {
+	t.Run("err single block too big", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.Finish(t)
+		var (
+			ctx, key = newRandKey()
+			fileId   = testutil.NewRandCid().String()
+			b        = testutil.NewRandBlock(cidSizeLimit + 1)
+		)
+
+		resp, err := fx.handler.BlockPushMany(ctx, &fileproto.BlockPushManyRequest{
+			FileBlocks: []*fileproto.FileBlocks{
+				{
+					SpaceId: key.SpaceId,
+					FileId:  fileId,
+					Blocks: []*fileproto.Block{
+						{Cid: b.Cid().Bytes(), Data: b.RawData()},
+					},
+				},
+			},
+		})
+		require.EqualError(t, err, fileprotoerr.ErrQuerySizeExceeded.Error())
+		assert.Nil(t, resp)
+	})
+}
+
 func TestFileNode_Get(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		fx := newFixture(t)

--- a/filenode/rpchandler.go
+++ b/filenode/rpchandler.go
@@ -126,6 +126,9 @@ func (r rpcHandler) BlockPushMany(ctx context.Context, req *fileproto.BlockPushM
 			if err != nil {
 				return nil, err
 			}
+			if len(block.Data) > cidSizeLimit {
+				return nil, fileprotoerr.ErrQuerySizeExceeded
+			}
 			chkc, err := c.Prefix().Sum(block.Data)
 			if err != nil {
 				return nil, err

--- a/index/bind.go
+++ b/index/bind.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"errors"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -108,15 +109,20 @@ func (ri *redisIndex) fileBind(ctx context.Context, key Key, fileId string, cids
 		fileInfo.Save(ctx, key, fileId, tx)
 		return nil
 	})
+	if err != nil {
+		return
+	}
 
 	// update cids
+	var saveErrs []error
 	for _, idx := range affectedCidIdx {
 		cids.entries[idx].Refs++
 		if saveErr := cids.entries[idx].Save(ctx, ri.cl); saveErr != nil {
 			log.WarnCtx(ctx, "unable to save cid info", zap.Error(saveErr), zap.String("cid", cids.entries[idx].Cid.String()))
+			saveErrs = append(saveErrs, saveErr)
 		}
 	}
-	return
+	return errors.Join(saveErrs...)
 }
 
 func (ri *redisIndex) fileBindCidStrings(ctx context.Context, key Key, fileId string, cidStrings []string, entry groupSpaceEntry) (err error) {

--- a/index/loader.go
+++ b/index/loader.go
@@ -249,7 +249,10 @@ func (ri *redisIndex) persistKeys(ctx context.Context, part int, stat *persistSt
 }
 
 func (ri *redisIndex) persistKey(ctx context.Context, storeKey, key string, deadline int64, stat *persistStat) (err error) {
-	mu := ri.redsync.NewMutex("_lock:" + key)
+	// use the same expiry as acquireKey: the default 8s expiry can elapse during slow
+	// persistent-store IO, letting a concurrent acquireKey mutate the key between our
+	// dump and the final delete, losing the update
+	mu := ri.redsync.NewMutex("_lock:"+key, redsync.WithExpiry(time.Minute*20))
 	if err = mu.LockContext(ctx); err != nil {
 		return
 	}

--- a/index/unbind.go
+++ b/index/unbind.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"errors"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -144,8 +145,12 @@ func (ri *redisIndex) fileUnbind(ctx context.Context, key Key, entry groupSpaceE
 		entry.group.Save(ctx, tx)
 		return nil
 	})
+	if err != nil {
+		return
+	}
 
 	// update cids
+	var saveErrs []error
 	for _, idx := range affectedCidIdx {
 		if cids.entries[idx].Refs != 0 {
 			cids.entries[idx].Refs--
@@ -155,7 +160,8 @@ func (ri *redisIndex) fileUnbind(ctx context.Context, key Key, entry groupSpaceE
 		}
 		if saveErr := cids.entries[idx].Save(ctx, ri.cl); saveErr != nil {
 			log.WarnCtx(ctx, "unable to save cid info", zap.Error(saveErr), zap.String("cid", cids.entries[idx].Cid.String()), zap.String("spaceId", key.SpaceId))
+			saveErrs = append(saveErrs, saveErr)
 		}
 	}
-	return
+	return errors.Join(saveErrs...)
 }

--- a/store/filedevstore/filedevstore.go
+++ b/store/filedevstore/filedevstore.go
@@ -145,6 +145,7 @@ func (s *fsstore) IndexGet(ctx context.Context, key string) (value []byte, err e
 		if errors.Is(err, anystore.ErrDocNotFound) {
 			return nil, nil
 		}
+		return nil, err
 	}
 	return slices.Clone(doc.Value().GetBytes("d")), nil
 }


### PR DESCRIPTION
Four independent correctness fixes in the index/filenode layer (one commit each).

## Surface cid save errors in bind/unbind
`fileBind`/`fileUnbind` ignored the error from their group/space `TxPipelined` and went on to mutate the global per-cid `Refs` even if the transaction had not committed, and swallowed per-cid `Save` failures. Both now return on tx error and join+return the cid save errors, so a `Refs` divergence surfaces to the caller. Rebind/reunbind of already-processed cids is idempotent, so client retries are safe.

## Match acquireKey lock expiry in persistKey
`persistKey` locked `_lock:{key}` with redsync's default ~8s expiry while doing multi-step persistent-store IO. Slow IO could let the lock expire mid-persist and let a concurrent `acquireKey` mutate the key between the dump and the final delete, losing the update. Now uses the same 20m expiry as `acquireKey`.

## Enforce per-cid size limit in BlockPushMany
`BlockPushMany` only checked the 20Mb batch total, so a single block up to the total was accepted. Applies the same 4Mb per-cid cap that `BlockPush` enforces. Adds a test.

## Return error from filedevstore IndexGet
On a non-`ErrDocNotFound` error, `IndexGet` fell through and dereferenced a possibly-nil doc. Returns the error instead.